### PR TITLE
refactor: reduce bool pattern-matching

### DIFF
--- a/src/ppx/codecs.ml
+++ b/src/ppx/codecs.ml
@@ -27,108 +27,52 @@ and generate_constr_codecs { do_encode; do_decode }
     { Location.txt = identifier; loc } =
   let open Longident in
   match identifier with
-  | Lident "string" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.stringToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.stringFromJson]
-        | false -> None ))
-  | Lident "int" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.intToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.intFromJson]
-        | false -> None ))
-  | Lident "int64" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.int64ToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.int64FromJson]
-        | false -> None ))
-  | Lident "float" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.floatToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.floatFromJson]
-        | false -> None ))
-  | Lident "bool" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.boolToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.boolFromJson]
-        | false -> None ))
-  | Lident "unit" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.unitToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.unitFromJson]
-        | false -> None ))
-  | Lident "array" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.arrayToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.arrayFromJson]
-        | false -> None ))
-  | Lident "list" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.listToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.listFromJson]
-        | false -> None ))
-  | Lident "option" -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.optionToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.optionFromJson]
-        | false -> None ))
-  | Ldot (Ldot (Lident "Belt", "Result"), "t") -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.resultToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.resultFromJson]
-        | false -> None ))
-  | Ldot (Ldot (Lident "Js", "Dict"), "t") -> (
-      ( (match do_encode with
-        | true -> Some [%expr Spice.dictToJson]
-        | false -> None),
-        match do_decode with
-        | true -> Some [%expr Spice.dictFromJson]
-        | false -> None ))
-  | Ldot (Ldot (Lident "Js", "Json"), "t") -> (
-      ( (match do_encode with true -> Some [%expr fun v -> v] | false -> None),
-        match do_decode with
-        | true -> Some [%expr fun v -> Belt.Result.Ok v]
-        | false -> None ))
-  | Lident s -> (
-      ( (match do_encode with
-        | true -> Some (make_ident_expr (s ^ Utils.encoder_func_suffix))
-        | false -> None),
-        match do_decode with
-        | true -> Some (make_ident_expr (s ^ Utils.decoder_func_suffix))
-        | false -> None ))
-  | Ldot (left, right) -> (
-      ( (match do_encode with
-        | true ->
-            Some
-              (Exp.ident
-                 (mknoloc (Ldot (left, right ^ Utils.encoder_func_suffix))))
-        | false -> None),
-        match do_decode with
-        | true ->
-            Some
-              (Exp.ident
-                 (mknoloc (Ldot (left, right ^ Utils.decoder_func_suffix))))
-        | false -> None ))
+  | Lident "string" ->
+      ( some_if_true do_encode [%expr Spice.stringToJson],
+        some_if_true do_decode [%expr Spice.stringFromJson] )
+  | Lident "int" ->
+      ( some_if_true do_encode [%expr Spice.intToJson],
+        some_if_true do_decode [%expr Spice.intFromJson] )
+  | Lident "int64" ->
+      ( some_if_true do_encode [%expr Spice.int64ToJson],
+        some_if_true do_decode [%expr Spice.int64FromJson] )
+  | Lident "float" ->
+      ( some_if_true do_encode [%expr Spice.floatToJson],
+        some_if_true do_decode [%expr Spice.floatFromJson] )
+  | Lident "bool" ->
+      ( some_if_true do_encode [%expr Spice.boolToJson],
+        some_if_true do_decode [%expr Spice.boolFromJson] )
+  | Lident "unit" ->
+      ( some_if_true do_encode [%expr Spice.unitToJson],
+        some_if_true do_decode [%expr Spice.unitFromJson] )
+  | Lident "array" ->
+      ( some_if_true do_encode [%expr Spice.arrayToJson],
+        some_if_true do_decode [%expr Spice.arrayFromJson] )
+  | Lident "list" ->
+      ( some_if_true do_encode [%expr Spice.listToJson],
+        some_if_true do_decode [%expr Spice.listFromJson] )
+  | Lident "option" ->
+      ( some_if_true do_encode [%expr Spice.optionToJson],
+        some_if_true do_decode [%expr Spice.optionFromJson] )
+  | Ldot (Ldot (Lident "Belt", "Result"), "t") ->
+      ( some_if_true do_encode [%expr Spice.resultToJson],
+        some_if_true do_decode [%expr Spice.resultFromJson] )
+  | Ldot (Ldot (Lident "Js", "Dict"), "t") ->
+      ( some_if_true do_encode [%expr Spice.dictToJson],
+        some_if_true do_decode [%expr Spice.dictFromJson] )
+  | Ldot (Ldot (Lident "Js", "Json"), "t") ->
+      ( some_if_true do_encode [%expr fun v -> v],
+        some_if_true do_decode [%expr fun v -> Belt.Result.Ok v] )
+  | Lident s ->
+      ( some_if_true do_encode (make_ident_expr (s ^ Utils.encoder_func_suffix)),
+        some_if_true do_decode (make_ident_expr (s ^ Utils.decoder_func_suffix))
+      )
+  | Ldot (left, right) ->
+      ( some_if_true do_encode
+          (Exp.ident (mknoloc (Ldot (left, right ^ Utils.encoder_func_suffix)))),
+        some_if_true do_decode
+          (Exp.ident (mknoloc (Ldot (left, right ^ Utils.decoder_func_suffix))))
+      )
   | Lapply (_, _) -> fail loc "Lapply syntax not yet handled by spice"
 
 and generate_codecs ({ do_encode; do_decode } as generator_settings)
@@ -138,52 +82,36 @@ and generate_codecs ({ do_encode; do_decode } as generator_settings)
   | Ptyp_arrow (_, _, _) ->
       fail ptyp_loc "Can't generate codecs for function type"
   | Ptyp_package _ -> fail ptyp_loc "Can't generate codecs for module type"
-  | Ptyp_tuple types -> (
+  | Ptyp_tuple types ->
       let composite_codecs =
         List.map (generate_codecs generator_settings) types
       in
-      ( (match do_encode with
-        | true ->
-            Some
-              (composite_codecs
-              |> List.map (fun (e, _) -> Option.get e)
-              |> Tuple.generate_encoder)
-        | false -> None),
-        match do_decode with
-        | true ->
-            Some
-              (composite_codecs
-              |> List.map (fun (_, d) -> Option.get d)
-              |> Tuple.generate_decoder)
-        | false -> None ))
-  | Ptyp_var s -> (
-      ( (match do_encode with
-        | true -> Some (make_ident_expr (encoder_var_prefix ^ s))
-        | false -> None),
-        match do_decode with
-        | true -> Some (make_ident_expr (decoder_var_prefix ^ s))
-        | false -> None ))
+      ( some_if_true do_encode
+          (composite_codecs
+          |> List.map (fun (e, _) -> Option.get e)
+          |> Tuple.generate_encoder),
+        some_if_true do_decode
+          (composite_codecs
+          |> List.map (fun (_, d) -> Option.get d)
+          |> Tuple.generate_decoder) )
+  | Ptyp_var s ->
+      ( some_if_true do_encode (make_ident_expr (encoder_var_prefix ^ s)),
+        some_if_true do_decode (make_ident_expr (decoder_var_prefix ^ s)) )
   | Ptyp_constr (constr, typeArgs) -> (
       let custom_codec = get_attribute_by_name ptyp_attributes "spice.codec" in
       let encode, decode =
         match custom_codec with
         | Ok None -> generate_constr_codecs generator_settings constr
-        | Ok (Some attribute) -> (
+        | Ok (Some attribute) ->
             let expr = get_expression_from_payload attribute in
-            ( (match do_encode with
-              | true ->
-                  Some
-                    [%expr
-                      let e, _ = [%e expr] in
-                      e]
-              | false -> None),
-              match do_decode with
-              | true ->
-                  Some
-                    [%expr
-                      let _, d = [%e expr] in
-                      d]
-              | false -> None ))
+            ( some_if_true do_encode
+                [%expr
+                  let e, _ = [%e expr] in
+                  e],
+              some_if_true do_decode
+                [%expr
+                  let _, d = [%e expr] in
+                  d] )
         | Error s -> fail ptyp_loc s
       in
       match List.length typeArgs = 0 with

--- a/src/ppx/polyvariants.ml
+++ b/src/ppx/polyvariants.ml
@@ -219,15 +219,12 @@ let generate_codecs ({ do_encode; do_decode } as generator_settings) row_fields
   in
 
   let encoder =
-    match do_encode with
-    | true ->
-        List.map
-          (generate_encoder_case generator_settings unboxed has_attr_as)
-          parsed_fields
-        |> Exp.match_ [%expr v]
-        |> Exp.fun_ Asttypes.Nolabel None [%pat? v]
-        |> Option.some
-    | false -> None
+    some_if_true do_encode
+      (List.map
+         (generate_encoder_case generator_settings unboxed has_attr_as)
+         parsed_fields
+      |> Exp.match_ [%expr v]
+      |> Exp.fun_ Asttypes.Nolabel None [%pat? v])
   in
 
   let decoder =

--- a/src/ppx/records.ml
+++ b/src/ppx/records.ml
@@ -124,9 +124,5 @@ let parse_decl generator_settings
 let generate_codecs ({ do_encode; do_decode } as generator_settings) decls
     unboxed =
   let parsed_decls = List.map (parse_decl generator_settings) decls in
-  ( (match do_encode with
-    | true -> Some (generate_encoder parsed_decls unboxed)
-    | false -> None),
-    match do_decode with
-    | true -> Some (generate_decoder parsed_decls unboxed)
-    | false -> None )
+  ( some_if_true do_encode (generate_encoder parsed_decls unboxed),
+    some_if_true do_decode (generate_decoder parsed_decls unboxed) )

--- a/src/ppx/utils.ml
+++ b/src/ppx/utils.ml
@@ -113,3 +113,5 @@ let attr_warning expr =
     attr_payload = PStr [ { pstr_desc = Pstr_eval (expr, []); pstr_loc = loc } ];
     attr_loc = loc;
   }
+
+let some_if_true cond a = match cond with true -> Some a | false -> None

--- a/src/ppx/variants.ml
+++ b/src/ppx/variants.ml
@@ -188,15 +188,11 @@ let generate_codecs ({ do_encode; do_decode } as generator_settings)
   in
 
   let encoder =
-    match do_encode with
-    | true ->
-        parsed_decls
-        |> List.map
-             (generate_encoder_case generator_settings unboxed has_attr_as)
-        |> Exp.match_ [%expr v]
-        |> Exp.fun_ Asttypes.Nolabel None [%pat? v]
-        |> Option.some
-    | false -> None
+    some_if_true do_encode
+      (parsed_decls
+      |> List.map (generate_encoder_case generator_settings unboxed has_attr_as)
+      |> Exp.match_ [%expr v]
+      |> Exp.fun_ Asttypes.Nolabel None [%pat? v])
   in
 
   let decoder =


### PR DESCRIPTION
OCaml does not have a ternary operator. So I create an alternative function to reduce the redundant code.