### PR TITLE
Build in docker container for better linking statically

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Opam init
+        run: opam init -y
+
       - name: Install deps
         run: opam install . --deps-only --with-test
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Opam init
-        run: opam init -a
+        run: opam init -a --disable-sandboxing
 
       - name: Install deps
         run: opam install . --deps-only --with-test

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -14,7 +14,9 @@ jobs:
         os: [ubuntu-latest]
         ocaml-compiler:
           - 4.12.1
-    container: ocaml/opam:alpine-3.16-ocaml-4.12
+    container:
+      image: ocaml/opam:alpine-3.16-ocaml-4.12
+      options: --user root
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -21,11 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use OCaml ${{ matrix.ocaml-compiler}}
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-
       - name: Install deps
         run: opam install . --deps-only --with-test
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Opam init
-        run: opam init -y
+        run: opam init -a
 
       - name: Install deps
         run: opam install . --deps-only --with-test

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Opam init
-        run: opam init -a --disable-sandboxing
+        run: opam init -a --disable-sandboxing --compiler=4.12.1
 
       - name: Install deps
         run: opam install . --deps-only --with-test

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -14,6 +14,7 @@ jobs:
         os: [ubuntu-latest]
         ocaml-compiler:
           - 4.12.1
+    container: ocaml/opam:alpine-3.16-ocaml-4.12
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,15 @@ jobs:
         os: [ubuntu-latest]
         ocaml-compiler:
           - 4.12.1
+    container:
+      image: ocaml/opam:alpine-3.16-ocaml-4.12
+      options: --user root
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use OCaml ${{ matrix.ocaml-compiler}}
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - name: Opam init
+        run: opam init -a --disable-sandboxing --compiler=4.12.1
 
       - name: Install deps
         run: opam install . --deps-only --with-test

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -20,14 +20,15 @@ jobs:
         os: [ubuntu-latest]
         ocaml-compiler:
           - 4.12.1
+    container:
+      image: ocaml/opam:alpine-3.16-ocaml-4.12
+      options: --user root
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use OCaml ${{ matrix.ocaml-compiler}}
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - name: Opam init
+        run: opam init -a --disable-sandboxing --compiler=4.12.1
 
       - name: Install deps
         run: opam install . --deps-only --with-test


### PR DESCRIPTION
Using `ocaml/opam:alpine-3.16-ocaml-4.12` that has the musl which is an alternative for glibc. Building in this container would make a better linking statically for Linux binary.