### PR TITLE
Update README from Yarn to pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ Make sure running tests in `/test`
 cd test
 
 (install dependencies)
-yarn
+pnpm install
 
 (build --watch)
-yarn res:clean && yarn res:watch
+pnpm res:clean && pnpm res:watch
 
 (run test --watch)
-yarn test:watch
+pnpm test:watch
 ```


### PR DESCRIPTION
This pull request updates the README to reflect our switch from Yarn to pnpm for managing test development, in PR #74. The test installation instructions have been revised to provide clearer guidance.