### PR TITLE
Upgrade ocaml compiler 4.14.2 for linux

### DIFF
--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "ocaml.sandbox": {
     "kind": "opam",
-    "switch": "4.14.0"
+    "switch": "4.14.2"
   }
 }

--- a/src/ppx_spice.opam
+++ b/src/ppx_spice.opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/green-labs/ppx_spice"
 bug-reports: "https://github.com/green-labs/ppx_spice/issues"
 dev-repo: "git+https://github.com/green-labs/ppx_spice.git"
 depends: [
-  "ocaml" { = "4.14.0"}
+  "ocaml" {>= "4.14.0" & <= "4.14.2"}
   "dune" { >= "2.8"}
   "ppxlib" { = "0.28.0"}
 ]


### PR DESCRIPTION
- Linux build on OCaml 4.14.0 fails during ocaml-base-compiler with Primitive(*pc)(...) being treated as a zero-arg function pointer, causing “too many arguments” errors in interp.c (rooted in caml/prims.h’s macro). Seen with GCC 15; build stops at world.opt.
- OCaml 4.14.2 rewrites those macros to Primitive1/2/…/N, so upgrading to 4.14.2 fixes the Linux build.