### PR TITLE
fix: correct arity for generic codec signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# 0.3.5 (unreleased)
+
+- Fixes [#105](https://github.com/green-labs/ppx_spice/issues/105) Arity of generated codecs was incorrect, causing a type error when called.
+
 # 0.3.4
 
 - migration to mununki

--- a/src/ppx/signature.ml
+++ b/src/ppx/signature.ml
@@ -2,26 +2,51 @@ open Ppxlib
 open Parsetree
 open Utils
 
-let rec add_encoder_params param_names result_type =
+(** For parameterized types, generate a function type that takes all type
+    parameter codecs at once and returns the final encoder.
+
+    e.g., for [type t<'a, 'b>], generates:
+    [('a => JSON.t, 'b => JSON.t) => t<'a, 'b> => JSON.t] *)
+let add_encoder_params param_names result_type =
   match param_names with
   | [] -> result_type
-  | hd :: tl ->
-      [%type: ([%t Ast_helper.Typ.var hd] -> JSON.t) -> [%t result_type]]
-      |> Utils.ctyp_arrow ~arity:1 |> add_encoder_params tl
+  | _ ->
+      let num_params, params_arrow =
+        List.fold_right
+          (fun name (count, acc) ->
+            let param_type =
+              [%type: [%t Ast_helper.Typ.var name] -> JSON.t]
+              |> Utils.ctyp_arrow ~arity:1
+            in
+            (count + 1, [%type: [%t param_type] -> [%t acc]]))
+          param_names (0, result_type)
+      in
+      Utils.ctyp_arrow ~arity:num_params params_arrow
 
 let make_result_type value_type =
   [%type: ([%t value_type], Spice.decodeError) result]
 
-let rec add_decoder_params param_names result_type =
+(** For parameterized types, generate a function type that takes all type
+    parameter codecs at once and returns the final decoder.
+
+    e.g., for [type t<'a, 'b>], generates:
+    [(JSON.t => result<'a, _>, JSON.t => result<'b, _>) =>
+     JSON.t => result<t<'a, 'b>, _>] *)
+let add_decoder_params param_names result_type =
   match param_names with
   | [] -> result_type
-  | hd :: tl ->
-      let decoder_param =
-        [%type: JSON.t -> [%t make_result_type (Ast_helper.Typ.var hd)]]
-        |> Utils.ctyp_arrow ~arity:1
+  | _ ->
+      let num_params, params_arrow =
+        List.fold_right
+          (fun name (count, acc) ->
+            let param_type =
+              [%type: JSON.t -> [%t make_result_type (Ast_helper.Typ.var name)]]
+              |> Utils.ctyp_arrow ~arity:1
+            in
+            (count + 1, [%type: [%t param_type] -> [%t acc]]))
+          param_names (0, result_type)
       in
-      [%type: [%t decoder_param] -> [%t result_type]]
-      |> Utils.ctyp_arrow ~arity:1 |> add_decoder_params tl
+      Utils.ctyp_arrow ~arity:num_params params_arrow
 
 let generate_sig_decls { do_encode; do_decode } type_name param_names =
   let encoder_pat = type_name ^ Utils.encoder_func_suffix in
@@ -40,7 +65,7 @@ let generate_sig_decls { do_encode; do_decode } type_name param_names =
         decls
         @ [
             [%type: [%t value_type] -> JSON.t] |> Utils.ctyp_arrow ~arity:1
-            |> add_encoder_params (List.rev param_names)
+            |> add_encoder_params param_names
             |> Ast_helper.Val.mk (mknoloc encoder_pat)
             |> Ast_helper.Sig.value;
           ]
@@ -53,7 +78,7 @@ let generate_sig_decls { do_encode; do_decode } type_name param_names =
         @ [
             [%type: JSON.t -> [%t make_result_type value_type]]
             |> Utils.ctyp_arrow ~arity:1
-            |> add_decoder_params (List.rev param_names)
+            |> add_decoder_params param_names
             |> Ast_helper.Val.mk (mknoloc decoder_pat)
             |> Ast_helper.Sig.value;
           ]

--- a/test/src/Polyvariants.res
+++ b/test/src/Polyvariants.res
@@ -10,3 +10,16 @@ type t2 = [@spice.as(1.0) #one | @spice.as(2.0) #two]
 // Types for testing error paths
 @spice.decode
 type withArgs = [#WithArgs(int, string)]
+
+// Generic polyvariants with type parameters
+@spice
+type t3<'a> = [#Some('a) | #None]
+
+let t3_string_encode = t3_encode(Spice.stringToJson)
+let t3_string_decode = t3_decode(Spice.stringFromJson)
+
+@spice
+type t4<'a, 'b> = [#Left('a) | #Right('b) | #Both('a, 'b)]
+
+let t4_string_int_encode = t4_encode(Spice.stringToJson, Spice.intToJson)
+let t4_string_int_decode = t4_decode(Spice.stringFromJson, Spice.intFromJson)

--- a/test/src/Polyvariants.resi
+++ b/test/src/Polyvariants.resi
@@ -10,3 +10,16 @@ type t2 = [@spice.as(1.0) #one | @spice.as(2.0) #two]
 // Types for testing error paths
 @spice.decode
 type withArgs = [#WithArgs(int, string)]
+
+// Generic polyvariants with type parameters
+@spice
+type t3<'a> = [#Some('a) | #None]
+
+let t3_string_encode: t3<string> => JSON.t
+let t3_string_decode: JSON.t => Spice.result<t3<string>>
+
+@spice
+type t4<'a, 'b> = [#Left('a) | #Right('b) | #Both('a, 'b)]
+
+let t4_string_int_encode: t4<string, int> => JSON.t
+let t4_string_int_decode: JSON.t => Spice.result<t4<string, int>>

--- a/test/src/Records.res
+++ b/test/src/Records.res
@@ -21,13 +21,13 @@ type t2 = {
   o: option<string>,
   n: Null.t<string>,
   on?: Null.t<string>,
-  n2: Null.t<string>
+  n2: Null.t<string>,
 }
 
 @spice
 type t3 = {
-  @spice.default(0) value: int
-  @spice.default(Some(1)) value2?: int
+  @spice.default(0) value: int,
+  @spice.default(Some(1)) value2?: int,
 }
 
 @spice
@@ -36,6 +36,7 @@ type t4 = {
   b?: bigint,
   c: option<bigint>,
 }
+
 // Types for testing nested error paths
 @spice.decode
 type inner = {value: int}
@@ -45,3 +46,18 @@ type outer = {one: inner}
 
 @spice.decode
 type deeplyNested = {level1: outer}
+
+@spice
+type t5<'data> = {a: array<'data>}
+
+let t5_string_encode = t5_encode(Spice.stringToJson)
+let t5_string_decode = t5_decode(Spice.stringFromJson)
+
+@spice
+type t6<'key, 'value> = {
+  key: 'key,
+  value: 'value,
+}
+
+let t6_string_int_encode = t6_encode(Spice.stringToJson, Spice.intToJson)
+let t6_string_int_decode = t6_decode(Spice.stringFromJson, Spice.intFromJson)

--- a/test/src/Records.resi
+++ b/test/src/Records.resi
@@ -21,13 +21,13 @@ type t2 = {
   o: option<string>,
   n: Null.t<string>,
   on?: Null.t<string>,
-  n2: Null.t<string>
+  n2: Null.t<string>,
 }
 
 @spice
 type t3 = {
-  @spice.default(0) value: int
-  @spice.default(Some(1)) value2?: int
+  @spice.default(0) value: int,
+  @spice.default(Some(1)) value2?: int,
 }
 
 @spice
@@ -46,3 +46,18 @@ type outer = {one: inner}
 
 @spice.decode
 type deeplyNested = {level1: outer}
+
+@spice
+type t5<'data> = {a: array<'data>}
+
+let t5_string_encode: t5<string> => JSON.t
+let t5_string_decode: JSON.t => Spice.result<t5<string>>
+
+@spice
+type t6<'key, 'value> = {
+  key: 'key,
+  value: 'value,
+}
+
+let t6_string_int_encode: t6<string, int> => JSON.t
+let t6_string_int_decode: JSON.t => Spice.result<t6<string, int>>

--- a/test/src/Variants.res
+++ b/test/src/Variants.res
@@ -16,3 +16,16 @@ type t4 = | @spice.as(1.0) One | @spice.as(2.0) Two
 // Types for testing error paths
 @spice.decode
 type withArgs = WithArgs(int, string)
+
+// Generic variants with type parameters
+@spice
+type t5<'a> = Some('a) | None
+
+let t5_string_encode = t5_encode(Spice.stringToJson)
+let t5_string_decode = t5_decode(Spice.stringFromJson)
+
+@spice
+type t6<'a, 'b> = Left('a) | Right('b) | Both('a, 'b)
+
+let t6_string_int_encode = t6_encode(Spice.stringToJson, Spice.intToJson)
+let t6_string_int_decode = t6_decode(Spice.stringFromJson, Spice.intFromJson)

--- a/test/src/Variants.resi
+++ b/test/src/Variants.resi
@@ -16,3 +16,16 @@ type t4 = | @spice.as(1.0) One | @spice.as(2.0) Two
 // Types for testing error paths
 @spice.decode
 type withArgs = WithArgs(int, string)
+
+// Generic variants with type parameters
+@spice
+type t5<'a> = Some('a) | None
+
+let t5_string_encode: t5<string> => JSON.t
+let t5_string_decode: JSON.t => Spice.result<t5<string>>
+
+@spice
+type t6<'a, 'b> = Left('a) | Right('b) | Both('a, 'b)
+
+let t6_string_int_encode: t6<string, int> => JSON.t
+let t6_string_int_decode: JSON.t => Spice.result<t6<string, int>>

--- a/test/test/__tests__/spec/polyvariants_test.res
+++ b/test/test/__tests__/spec/polyvariants_test.res
@@ -65,3 +65,61 @@ zoraBlock("polyvariant error path includes correct index", t => {
     }
   })
 })
+
+zoraBlock("generic polyvariant with single type parameter", t => {
+  let someEncoded = #Some("hello")->Polyvariants.t3_string_encode
+  t->testEqual(
+    `encode #Some("hello")`,
+    someEncoded,
+    JSON.Array([JSON.String("Some"), JSON.String("hello")]),
+  )
+
+  let noneEncoded = #None->Polyvariants.t3_string_encode
+  t->testEqual(`encode #None`, noneEncoded, JSON.Array([JSON.String("None")]))
+
+  let someDecoded =
+    JSON.Array([JSON.String("Some"), JSON.String("hello")])->Polyvariants.t3_string_decode
+  t->testEqual(`decode #Some`, someDecoded, Ok(#Some("hello")))
+
+  let noneDecoded = JSON.Array([JSON.String("None")])->Polyvariants.t3_string_decode
+  t->testEqual(`decode #None`, noneDecoded, Ok(#None))
+})
+
+zoraBlock("generic polyvariant with multiple type parameters", t => {
+  let leftEncoded = #Left("hello")->Polyvariants.t4_string_int_encode
+  t->testEqual(
+    `encode #Left("hello")`,
+    leftEncoded,
+    JSON.Array([JSON.String("Left"), JSON.String("hello")]),
+  )
+
+  let rightEncoded = #Right(42)->Polyvariants.t4_string_int_encode
+  t->testEqual(
+    `encode #Right(42)`,
+    rightEncoded,
+    JSON.Array([JSON.String("Right"), JSON.Number(42.0)]),
+  )
+
+  let bothEncoded = #Both("hello", 42)->Polyvariants.t4_string_int_encode
+  t->testEqual(
+    `encode #Both("hello", 42)`,
+    bothEncoded,
+    JSON.Array([JSON.String("Both"), JSON.String("hello"), JSON.Number(42.0)]),
+  )
+
+  let leftDecoded =
+    JSON.Array([JSON.String("Left"), JSON.String("hello")])->Polyvariants.t4_string_int_decode
+  t->testEqual(`decode #Left`, leftDecoded, Ok(#Left("hello")))
+
+  let rightDecoded =
+    JSON.Array([JSON.String("Right"), JSON.Number(42.0)])->Polyvariants.t4_string_int_decode
+  t->testEqual(`decode #Right`, rightDecoded, Ok(#Right(42)))
+
+  let bothDecoded =
+    JSON.Array([
+      JSON.String("Both"),
+      JSON.String("hello"),
+      JSON.Number(42.0),
+    ])->Polyvariants.t4_string_int_decode
+  t->testEqual(`decode #Both`, bothDecoded, Ok(#Both("hello", 42)))
+})

--- a/test/test/__tests__/spec/records_test.res
+++ b/test/test/__tests__/spec/records_test.res
@@ -223,3 +223,42 @@ zoraBlock("deeply nested record error path", t => {
     }
   })
 })
+
+zoraBlock("generic record with single type parameter", t => {
+  let sample = dict{
+    "a": JSON.Array([JSON.String("one"), JSON.String("two"), JSON.String("three")]),
+  }
+  let sampleJson = sample->JSON.Object
+
+  let sampleRecord: Records.t5<string> = {
+    a: ["one", "two", "three"],
+  }
+
+  let encoded = sampleRecord->Records.t5_string_encode
+  t->testEqual(`encode`, encoded, sampleJson)
+
+  let decoded = sampleJson->Records.t5_string_decode
+  let expectedDecoded: Records.t5<string> = {
+    a: ["one", "two", "three"],
+  }
+  t->testEqual(`decode`, decoded, Ok(expectedDecoded))
+})
+
+zoraBlock("generic record with multiple type parameters", t => {
+  let sample = dict{
+    "key": JSON.String("myKey"),
+    "value": JSON.Number(42.0),
+  }
+  let sampleJson = sample->JSON.Object
+
+  let sampleRecord: Records.t6<string, int> = {
+    key: "myKey",
+    value: 42,
+  }
+
+  let encoded = sampleRecord->Records.t6_string_int_encode
+  t->testEqual(`encode`, encoded, sampleJson)
+
+  let decoded = sampleJson->Records.t6_string_int_decode
+  t->testEqual(`decode`, decoded, Ok(sampleRecord))
+})

--- a/test/test/__tests__/spec/variants_test.res
+++ b/test/test/__tests__/spec/variants_test.res
@@ -81,3 +81,61 @@ zoraBlock("variant error path includes correct index", t => {
     }
   })
 })
+
+zoraBlock("generic variant with single type parameter", t => {
+  let someEncoded = Variants.Some("hello")->Variants.t5_string_encode
+  t->testEqual(
+    `encode Some("hello")`,
+    someEncoded,
+    JSON.Array([JSON.String("Some"), JSON.String("hello")]),
+  )
+
+  let noneEncoded = Variants.None->Variants.t5_string_encode
+  t->testEqual(`encode None`, noneEncoded, JSON.Array([JSON.String("None")]))
+
+  let someDecoded =
+    JSON.Array([JSON.String("Some"), JSON.String("hello")])->Variants.t5_string_decode
+  t->testEqual(`decode Some`, someDecoded, Ok(Variants.Some("hello")))
+
+  let noneDecoded = JSON.Array([JSON.String("None")])->Variants.t5_string_decode
+  t->testEqual(`decode None`, noneDecoded, Ok(Variants.None))
+})
+
+zoraBlock("generic variant with multiple type parameters", t => {
+  let leftEncoded = Variants.Left("hello")->Variants.t6_string_int_encode
+  t->testEqual(
+    `encode Left("hello")`,
+    leftEncoded,
+    JSON.Array([JSON.String("Left"), JSON.String("hello")]),
+  )
+
+  let rightEncoded = Variants.Right(42)->Variants.t6_string_int_encode
+  t->testEqual(
+    `encode Right(42)`,
+    rightEncoded,
+    JSON.Array([JSON.String("Right"), JSON.Number(42.0)]),
+  )
+
+  let bothEncoded = Variants.Both("hello", 42)->Variants.t6_string_int_encode
+  t->testEqual(
+    `encode Both("hello", 42)`,
+    bothEncoded,
+    JSON.Array([JSON.String("Both"), JSON.String("hello"), JSON.Number(42.0)]),
+  )
+
+  let leftDecoded =
+    JSON.Array([JSON.String("Left"), JSON.String("hello")])->Variants.t6_string_int_decode
+  t->testEqual(`decode Left`, leftDecoded, Ok(Variants.Left("hello")))
+
+  let rightDecoded =
+    JSON.Array([JSON.String("Right"), JSON.Number(42.0)])->Variants.t6_string_int_decode
+  t->testEqual(`decode Right`, rightDecoded, Ok(Variants.Right(42)))
+
+  let bothDecoded =
+    JSON.Array([
+      JSON.String("Both"),
+      JSON.String("hello"),
+      JSON.Number(42.0),
+    ])->Variants.t6_string_int_decode
+  t->testEqual(`decode Both`, bothDecoded, Ok(Variants.Both("hello", 42)))
+})


### PR DESCRIPTION
Fixes https://github.com/mununki/ppx_spice/issues/105

Generic types with multiple type parameters generated codec functions
with incorrect arity, causing each codec parameter to be curried
separately instead of grouped as an uncurried tuple.

- Refactored `add_encoder_params` and `add_decoder_params` to use
  `List.fold_right` and set the outer function arity to the total
  number of type parameters
- Refactored `add_params` to count parameters and set correct arity